### PR TITLE
Fix undefined method admin for ActionAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,10 @@ can create a constraint to restrict access to these routes.
       end
 
       def self.current_user(request)
-        session_token = request.cookie_jar.signed[:session_token]
-        ActionAuth::Session.find_by(id: session_token)&.action_auth_user.becomes(User)
+         session_token = request.cookie_jar.signed[:session_token]
+         session = ActionAuth::Session.find_by(id: session_token)
+         return nil unless session.present
+         session.action_auth_user&.becomes(User)
       end
     end
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ can create a constraint to restrict access to these routes.
       def self.current_user(request)
          session_token = request.cookie_jar.signed[:session_token]
          session = ActionAuth::Session.find_by(id: session_token)
-         return nil unless session.present
+         return nil unless session.present?
          session.action_auth_user&.becomes(User)
       end
     end

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ can create a constraint to restrict access to these routes.
 
       def self.current_user(request)
         session_token = request.cookie_jar.signed[:session_token]
-        ActionAuth::Session.find_by(id: session_token)&.action_auth_user
+        ActionAuth::Session.find_by(id: session_token)&.action_auth_user.becomes(User)
       end
     end
 


### PR DESCRIPTION
This PR addresses an issue when trying to authenticate an admin user.
![image](https://github.com/kobaltz/action_auth/assets/48605824/60e1dc23-c5c5-4333-91fb-b32b6efe3803)
