### PR TITLE
Remove ActionAuth Namespace

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    action_auth (0.3.0)
+    action_auth (1.0.0)
       bcrypt (~> 3.1.0)
       rails (~> 7.1)
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ user experience akin to that offered by the well-regarded Devise gem.
 7. [License](#license)
 8. [Credits](#credits)
 
+## Breaking Changes
+
+With the release of v1.0.0, there are some breaking changes that have been introduced. The
+biggest change is that the `ActionAuth::User` model now uses the table name of `users` instead
+of `action_auth_users`. This was done to make it easier to integrate with your application
+without having to worry about the table name. If you have an existing application that is
+using ActionAuth, you will need to rename the table to `users` with a migration like
+
+```ruby
+rename_table :action_auth_users, :users
+```
+
 ## Installation
 Add this line to your application's Gemfile:
 
@@ -242,28 +254,10 @@ end
 
 #### Generating an association
 
-There's one little gotcha when generating the associations. We are using `user:belongs_to` instead of
-`action_auth_user:belongs_to`. However, when the foreign key is generated, it will look for the users table
-instead of the action_auth_users table. To get around this, we'll need to modify the migration.
+We are using `user:belongs_to` instead of `action_auth_user:belongs_to`.
 
 ```bash
 bin/rails g scaffold posts user:belongs_to title
-```
-
-We can update the `foreign_key` from `true` to `{ to_table: :action_auth_users }` to get around this.
-
-```ruby
-# db/migrate/XXXXXXXXXXX_create_posts.rb
-class CreatePosts < ActiveRecord::Migration[7.1]
-  def change
-    create_table :posts do |t|
-      t.belongs_to :user, null: false, foreign_key: { to_table: :action_auth_users }
-      t.string :title
-
-      t.timestamps
-    end
-  end
-end
 ```
 
 And the post model doesn't need anything special to ActionAuth.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,31 @@ using ActionAuth, you will need to rename the table to `users` with a migration 
 rename_table :action_auth_users, :users
 ```
 
+Coming from `v0.3.0` to `v1.0.0`, you will need to create a migration to rename the table and foreign keys.
+
+```ruby
+class UpgradeActionAuth < ActiveRecord::Migration[7.1]
+  def change
+    rename_table :action_auth_users, :users
+
+    rename_table :action_auth_sessions, :sessions
+    rename_column :sessions, :action_auth_user_id, :user_id
+
+    rename_table :action_auth_webauthn_credentials, :webauthn_credentials
+    rename_column :webauthn_credentials, :action_auth_user_id, :user_id
+  end
+end
+```
+
+You will then need to undo the migrations where the foreign keys were added in cases where `foreign_key: true` was
+changed to `foreign_key: { to_table: 'action_auth_users' }`. You can do this for each table with a migration like:
+
+```ruby
+add_foreign_key :user_settings, :users, column: :user_id unless foreign_key_exists?(:user_settings, :users)
+add_foreign_key :profiles, :users, column: :user_id unless foreign_key_exists?(:profiles, :users)
+add_foreign_key :nfcs, :users, column: :user_id unless foreign_key_exists?(:nfcs, :users)
+```
+
 ## Installation
 Add this line to your application's Gemfile:
 

--- a/app/controllers/action_auth/registrations_controller.rb
+++ b/app/controllers/action_auth/registrations_controller.rb
@@ -12,7 +12,7 @@ module ActionAuth
           send_email_verification
           redirect_to sign_in_path, notice: "Welcome! You have signed up successfully. Please check your email to verify your account."
         else
-          session_record = @user.action_auth_sessions.create!
+          session_record = @user.sessions.create!
           cookies.signed.permanent[:session_token] = { value: session_record.id, httponly: true }
 
           redirect_to sign_in_path, notice: "Welcome! You have signed up successfully"

--- a/app/controllers/action_auth/sessions_controller.rb
+++ b/app/controllers/action_auth/sessions_controller.rb
@@ -5,7 +5,7 @@ module ActionAuth
 
     def index
       @action_auth_wide = true
-      @sessions = Current.user.action_auth_sessions.order(created_at: :desc)
+      @sessions = Current.user.sessions.order(created_at: :desc)
     end
 
     def new
@@ -18,7 +18,7 @@ module ActionAuth
           redirect_to new_webauthn_credential_authentications_path
         else
           return if check_if_email_is_verified(user)
-          @session = user.action_auth_sessions.create
+          @session = user.sessions.create
           cookies.signed.permanent[:session_token] = { value: @session.id, httponly: true }
           redirect_to main_app.root_path, notice: "Signed in successfully"
         end
@@ -28,7 +28,7 @@ module ActionAuth
     end
 
     def destroy
-      session = Current.user.action_auth_sessions.find(params[:id])
+      session = Current.user.sessions.find(params[:id])
       session.destroy
       redirect_to main_app.root_path, notice: "That session has been logged out"
     end

--- a/app/controllers/action_auth/webauthn_credential_authentications_controller.rb
+++ b/app/controllers/action_auth/webauthn_credential_authentications_controller.rb
@@ -4,7 +4,7 @@ class ActionAuth::WebauthnCredentialAuthenticationsController < ApplicationContr
   layout "action_auth/application"
 
   def new
-    get_options = WebAuthn::Credential.options_for_get(allow: user.action_auth_webauthn_credentials.pluck(:external_id))
+    get_options = WebAuthn::Credential.options_for_get(allow: user.webauthn_credentials.pluck(:external_id))
     session[:current_challenge] = get_options.challenge
     @options = get_options
   end
@@ -12,7 +12,7 @@ class ActionAuth::WebauthnCredentialAuthenticationsController < ApplicationContr
   def create
     webauthn_credential = WebAuthn::Credential.from_get(params)
 
-    credential = user.action_auth_webauthn_credentials.find_by(external_id: webauthn_credential.id)
+    credential = user.webauthn_credentials.find_by(external_id: webauthn_credential.id)
 
     begin
       webauthn_credential.verify(
@@ -23,7 +23,7 @@ class ActionAuth::WebauthnCredentialAuthenticationsController < ApplicationContr
 
       credential.update!(sign_count: webauthn_credential.sign_count)
       session.delete(:webauthn_user_id)
-      session = user.action_auth_sessions.create
+      session = user.sessions.create
       cookies.signed.permanent[:session_token] = { value: session.id, httponly: true }
       render json: { status: "ok" }, status: :ok
     rescue WebAuthn::Error => e

--- a/app/controllers/action_auth/webauthn_credentials_controller.rb
+++ b/app/controllers/action_auth/webauthn_credentials_controller.rb
@@ -15,7 +15,7 @@ class ActionAuth::WebauthnCredentialsController < ApplicationController
         id: current_user.webauthn_id,
         name: current_user.email
       },
-      exclude: current_user.action_auth_webauthn_credentials.pluck(:external_id)
+      exclude: current_user.webauthn_credentials.pluck(:external_id)
     )
 
     session[:current_challenge] = create_options.challenge
@@ -34,7 +34,7 @@ class ActionAuth::WebauthnCredentialsController < ApplicationController
     begin
       webauthn_credential.verify(session[:current_challenge])
 
-      credential = current_user.action_auth_webauthn_credentials.build(
+      credential = current_user.webauthn_credentials.build(
         external_id: webauthn_credential.id,
         nickname: params[:credential_nickname],
         public_key: webauthn_credential.public_key,
@@ -53,7 +53,7 @@ class ActionAuth::WebauthnCredentialsController < ApplicationController
   end
 
   def destroy
-    current_user.action_auth_webauthn_credentials.destroy(params[:id])
+    current_user.webauthn_credentials.destroy(params[:id])
 
     redirect_to sessions_path
   end

--- a/app/models/action_auth/current.rb
+++ b/app/models/action_auth/current.rb
@@ -3,10 +3,6 @@ module ActionAuth
     attribute :session
     attribute :user_agent, :ip_address
 
-    delegate :action_auth_user, to: :session, allow_nil: true
-
-    def user
-      action_auth_user
-    end
+    delegate :user, to: :session, allow_nil: true
   end
 end

--- a/app/models/action_auth/session.rb
+++ b/app/models/action_auth/session.rb
@@ -1,6 +1,8 @@
 module ActionAuth
   class Session < ApplicationRecord
-    belongs_to :action_auth_user, class_name: "ActionAuth::User", foreign_key: "action_auth_user_id"
+    self.table_name = "sessions"
+
+    belongs_to :user, class_name: "ActionAuth::User", foreign_key: "user_id"
 
     before_create do
       self.user_agent = Current.user_agent

--- a/app/models/action_auth/webauthn_credential.rb
+++ b/app/models/action_auth/webauthn_credential.rb
@@ -1,5 +1,7 @@
 module ActionAuth
   class WebauthnCredential < ApplicationRecord
+    self.table_name = "webauthn_credentials"
+
     validates :external_id, :public_key, :nickname, :sign_count, presence: true
     validates :external_id, uniqueness: true
     validates :sign_count,

--- a/app/views/action_auth/sessions/index.html.erb
+++ b/app/views/action_auth/sessions/index.html.erb
@@ -41,7 +41,7 @@
         </tr>
       </thead>
       <tbody>
-        <% current_user.action_auth_webauthn_credentials.each do |credential| %>
+        <% current_user.webauthn_credentials.each do |credential| %>
           <%= content_tag :tr, id: dom_id(credential) do %>
             <td><%= credential.nickname %></td>
             <td nowrap><%= credential.created_at.strftime('%B %d, %Y') %></td>

--- a/db/migrate/20231107165548_create_action_auth_users.rb
+++ b/db/migrate/20231107165548_create_action_auth_users.rb
@@ -1,12 +1,12 @@
 class CreateActionAuthUsers < ActiveRecord::Migration[7.1]
   def change
-    create_table :action_auth_users do |t|
+    create_table :users do |t|
       t.string :email
       t.string :password_digest
       t.boolean :verified
 
       t.timestamps
     end
-    add_index :action_auth_users, :email, unique: true
+    add_index :users, :email, unique: true
   end
 end

--- a/db/migrate/20231107170349_create_action_auth_sessions.rb
+++ b/db/migrate/20231107170349_create_action_auth_sessions.rb
@@ -1,7 +1,7 @@
 class CreateActionAuthSessions < ActiveRecord::Migration[7.1]
   def change
-    create_table :action_auth_sessions do |t|
-      t.references :action_auth_user, null: false, foreign_key: true
+    create_table :sessions do |t|
+      t.references :user, null: false, foreign_key: true
       t.string :user_agent
       t.string :ip_address
 

--- a/db/migrate/20240111125859_add_webauthn_credentials.rb
+++ b/db/migrate/20240111125859_add_webauthn_credentials.rb
@@ -1,6 +1,6 @@
 class AddWebauthnCredentials < ActiveRecord::Migration[7.1]
   def change
-    create_table :action_auth_webauthn_credentials do |t|
+    create_table :webauthn_credentials do |t|
       t.string :external_id, null: false
       t.string :public_key, null: false
       t.string :nickname, null: false
@@ -8,7 +8,7 @@ class AddWebauthnCredentials < ActiveRecord::Migration[7.1]
 
       t.index :external_id, unique: true
 
-      t.references :action_auth_user, foreign_key: true
+      t.references :user, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20240111142545_add_webauthn_id_to_users.rb
+++ b/db/migrate/20240111142545_add_webauthn_id_to_users.rb
@@ -1,5 +1,5 @@
 class AddWebauthnIdToUsers < ActiveRecord::Migration[7.1]
   def change
-    add_column :action_auth_users, :webauthn_id, :string
+    add_column :users, :webauthn_id, :string
   end
 end

--- a/lib/action_auth/version.rb
+++ b/lib/action_auth/version.rb
@@ -1,3 +1,3 @@
 module ActionAuth
-  VERSION = "0.3.0"
+  VERSION = "1.0.0"
 end

--- a/test/controllers/action_auth/sessions_controller_test.rb
+++ b/test/controllers/action_auth/sessions_controller_test.rb
@@ -34,7 +34,7 @@ module ActionAuth
     test "should sign out" do
       sign_in_as(@user)
 
-      delete session_url(@user.action_auth_sessions.last)
+      delete session_url(@user.sessions.last)
       assert_response :redirect
     end
   end

--- a/test/controllers/action_auth/webauthn_credentials_controller_test.rb
+++ b/test/controllers/action_auth/webauthn_credentials_controller_test.rb
@@ -79,10 +79,10 @@ class WebauthnCredentialsControllerTest < ActionDispatch::IntegrationTest
 
     public_key_credential = fake_client.get(challenge: authentication_challenge)
     post(action_auth.webauthn_credential_authentications_path, params: public_key_credential)
-    delete action_auth.webauthn_credential_path(user.action_auth_webauthn_credentials.first.id)
+    delete action_auth.webauthn_credential_path(user.webauthn_credentials.first.id)
 
     assert_redirected_to action_auth.sessions_path
-    assert_empty user.reload.action_auth_webauthn_credentials
+    assert_empty user.reload.webauthn_credentials
   end
 
   private

--- a/test/dummy/app/controllers/posts_controller.rb
+++ b/test/dummy/app/controllers/posts_controller.rb
@@ -12,7 +12,7 @@ class PostsController < ApplicationController
 
   # GET /posts/new
   def new
-    @post = Post.new
+    @post = Current.user.posts.new
   end
 
   # GET /posts/1/edit
@@ -21,7 +21,7 @@ class PostsController < ApplicationController
 
   # POST /posts
   def create
-    @post = Post.new(post_params)
+    @post = Current.user.posts.new(post_params)
 
     if @post.save
       redirect_to @post, notice: "Post was successfully created."
@@ -53,6 +53,6 @@ class PostsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def post_params
-      params.require(:post).permit(:user_id, :title)
+      params.require(:post).permit(:title)
     end
 end

--- a/test/dummy/db/migrate/20240114051355_create_posts.rb
+++ b/test/dummy/db/migrate/20240114051355_create_posts.rb
@@ -1,7 +1,7 @@
 class CreatePosts < ActiveRecord::Migration[7.1]
   def change
     create_table :posts do |t|
-      t.belongs_to :user, null: false, foreign_key: { to_table: :action_auth_users }
+      t.belongs_to :user, null: false, foreign_key: true
       t.string :title
 
       t.timestamps

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,37 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.1].define(version: 2024_01_14_051355) do
-  create_table "action_auth_sessions", force: :cascade do |t|
-    t.integer "action_auth_user_id", null: false
-    t.string "user_agent"
-    t.string "ip_address"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["action_auth_user_id"], name: "index_action_auth_sessions_on_action_auth_user_id"
-  end
-
-  create_table "action_auth_users", force: :cascade do |t|
-    t.string "email"
-    t.string "password_digest"
-    t.boolean "verified"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "webauthn_id"
-    t.index ["email"], name: "index_action_auth_users_on_email", unique: true
-  end
-
-  create_table "action_auth_webauthn_credentials", force: :cascade do |t|
-    t.string "external_id", null: false
-    t.string "public_key", null: false
-    t.string "nickname", null: false
-    t.bigint "sign_count", default: 0, null: false
-    t.integer "action_auth_user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["action_auth_user_id"], name: "index_action_auth_webauthn_credentials_on_action_auth_user_id"
-    t.index ["external_id"], name: "index_action_auth_webauthn_credentials_on_external_id", unique: true
-  end
-
   create_table "posts", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "title"
@@ -50,7 +19,38 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_14_051355) do
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
-  add_foreign_key "action_auth_sessions", "action_auth_users"
-  add_foreign_key "action_auth_webauthn_credentials", "action_auth_users"
-  add_foreign_key "posts", "action_auth_users", column: "user_id"
+  create_table "sessions", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "user_agent"
+    t.string "ip_address"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_sessions_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "password_digest"
+    t.boolean "verified"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "webauthn_id"
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+  create_table "webauthn_credentials", force: :cascade do |t|
+    t.string "external_id", null: false
+    t.string "public_key", null: false
+    t.string "nickname", null: false
+    t.bigint "sign_count", default: 0, null: false
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["external_id"], name: "index_webauthn_credentials_on_external_id", unique: true
+    t.index ["user_id"], name: "index_webauthn_credentials_on_user_id"
+  end
+
+  add_foreign_key "posts", "users"
+  add_foreign_key "sessions", "users"
+  add_foreign_key "webauthn_credentials", "users"
 end

--- a/test/fixtures/action_auth/sessions.yml
+++ b/test/fixtures/action_auth/sessions.yml
@@ -1,11 +1,11 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  action_auth_user: one
+  user: one
   user_agent: MyString
   ip_address: MyString
 
 two:
-  action_auth_user: two
+  user: two
   user_agent: MyString
   ip_address: MyString

--- a/test/models/action_auth/session_test.rb
+++ b/test/models/action_auth/session_test.rb
@@ -6,16 +6,16 @@ module ActionAuth
       @user = action_auth_users(:one)
     end
 
-    test "should belong to action_auth_user" do
-      session = @user.action_auth_sessions.new
-      assert_respond_to session, :action_auth_user
+    test "should belong to user" do
+      session = @user.sessions.new
+      assert_respond_to session, :user
     end
 
     test "should set user_agent and ip_address before create" do
       Current.user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
       Current.ip_address = "192.168.1.1"
 
-      session = @user.action_auth_sessions.create
+      session = @user.sessions.create
 
       assert_equal Current.user_agent, session.user_agent
       assert_equal Current.ip_address, session.ip_address

--- a/test/models/action_auth/user_test.rb
+++ b/test/models/action_auth/user_test.rb
@@ -91,7 +91,7 @@ module ActionAuth
 
     test "should delete sessions after password change" do
       @user.save
-      session = @user.action_auth_sessions.create
+      session = @user.sessions.create
       @user.update(password: "newpassword123")
       assert_not Session.exists?(session.id)
     end

--- a/test/support/sign_in_as_helper.rb
+++ b/test/support/sign_in_as_helper.rb
@@ -1,6 +1,6 @@
 module SignInAsHelper
   def sign_in_as(user)
-    session = user.action_auth_sessions.create
+    session = user.sessions.create
     signed_cookies = ActionDispatch::Request.new(Rails.application.env_config.deep_dup).cookie_jar
     signed_cookies.signed[:session_token] = { value: session.id, httponly: true }
     cookies[:session_token] = signed_cookies[:session_token]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,7 +37,7 @@ class ActionDispatch::IntegrationTest
     ActionAuth::User.create!(
       email: email,
       password: password,
-      action_auth_webauthn_credentials: [
+      webauthn_credentials: [
         ActionAuth::WebauthnCredential.new(
           external_id: webauthn_credential.id,
           nickname: credential_nickname,


### PR DESCRIPTION
Remove ActionAuth Namespace
    
  - the user, session and webauthn_credential tables have had their ActionAuth namespace removed
  - tests updated to reflect the new tables
  - updated the models to use the table_name
  - updated README